### PR TITLE
Add option insiders with env-settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ To disable this feature entirely, pass the `--skipsync` flag.
 ### Custom settings directories
 
 If you're using an alternative release of VS Code such as VS Code Insiders, you
-will need to specify your configuration directory through the `VSCODE_CONFIG_DIR`
+must specify your configuration directory through the `VSCODE_CONFIG_DIR`
 environment variable.
 
-The following will make `sshcode` work with VS Code insiders:
+The following will make `sshcode` work with VS Code Insiders:
 
 ```bash
 export VSCODE_CONFIG_DIR="$HOME/.config/Code - Insiders/User"

--- a/README.md
+++ b/README.md
@@ -54,13 +54,14 @@ To disable this feature entirely, pass the `--skipsync` flag.
 ### Custom settings directories
 
 If you're using an alternative release of VS Code such as VS Code Insiders, you
-must specify your configuration directory through the `VSCODE_CONFIG_DIR`
-environment variable.
+must specify your settings directories through the `VSCODE_CONFIG_DIR` and
+`VSCODE_EXTENSIONS_DIR` environment variables.
 
 The following will make `sshcode` work with VS Code Insiders:
 
 ```bash
 export VSCODE_CONFIG_DIR="$HOME/.config/Code - Insiders/User"
+export VSCODE_EXTENSIONS_DIR="$HOME/.vscode-insiders/extensions"
 ```
 
 ### Sync-back

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ on follow-up connections to the same server.
 
 To disable this feature entirely, pass the `--skipsync` flag.
 
+### Custom settings directories
+
+If you're using an alternative release of VS Code such as VS Code Insiders, you
+will need to specify your configuration directory through the `VSCODE_CONFIG_DIR`
+environment variable.
+
+The following will make `sshcode` work with VS Code insiders:
+
+```bash
+export VSCODE_CONFIG_DIR="$HOME/.config/Code - Insiders/User"
+```
+
 ### Sync-back
 
 By default, VS Code changes on the remote server won't be synced back

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -36,6 +35,11 @@ func main() {
 		fmt.Printf(`Usage: [-skipsync] %v HOST [DIR] [SSH ARGS...]
 
 Start code-server over SSH.
+
+Environment variables:
+		`+vsCodeConfigDirEnv+`	use special VS Code settings dir.
+		`+vsCodeExtensionsDirEnv+`	use special VS Code extensions dir.
+
 More info: https://github.com/codercom/sshcode
 `, os.Args[0],
 		)
@@ -300,28 +304,4 @@ func rsync(src string, dest string, sshFlags string, excludePaths ...string) err
 	}
 
 	return nil
-}
-
-func configDir() (string, error) {
-	var path string
-	switch runtime.GOOS {
-	case "linux":
-		path = os.ExpandEnv("$HOME/.config/Code/User/")
-	case "darwin":
-		path = os.ExpandEnv("$HOME/Library/Application Support/Code/User/")
-	default:
-		return "", xerrors.Errorf("unsupported platform: %s", runtime.GOOS)
-	}
-	return filepath.Clean(path), nil
-}
-
-func extensionsDir() (string, error) {
-	var path string
-	switch runtime.GOOS {
-	case "linux", "darwin":
-		path = os.ExpandEnv("$HOME/.vscode/extensions/")
-	default:
-		return "", xerrors.Errorf("unsupported platform: %s", runtime.GOOS)
-	}
-	return filepath.Clean(path), nil
 }

--- a/settings.go
+++ b/settings.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"golang.org/x/xerrors"
+)
+
+const (
+	vsCodeConfigDirEnv     = "VSCODE_CONFIG_DIR"
+	vsCodeExtensionsDirEnv = "VSCODE_EXTENSIONS_DIR"
+)
+
+func configDir() (string, error) {
+	if env, ok := os.LookupEnv(vsCodeConfigDirEnv); ok {
+		return os.ExpandEnv(env), nil
+	}
+
+	var path string
+	switch runtime.GOOS {
+	case "linux":
+		path = os.ExpandEnv("$HOME/.config/Code/User/")
+	case "darwin":
+		path = os.ExpandEnv("$HOME/Library/Application Support/Code/User/")
+	default:
+		return "", xerrors.Errorf("unsupported platform: %s", runtime.GOOS)
+	}
+	return filepath.Clean(path), nil
+}
+
+func extensionsDir() (string, error) {
+	if env, ok := os.LookupEnv(vsCodeExtensionsDirEnv); ok {
+		return os.ExpandEnv(env), nil
+	}
+
+	var path string
+	switch runtime.GOOS {
+	case "linux", "darwin":
+		path = os.ExpandEnv("$HOME/.vscode/extensions/")
+	default:
+		return "", xerrors.Errorf("unsupported platform: %s", runtime.GOOS)
+	}
+	return filepath.Clean(path), nil
+}

--- a/settings.go
+++ b/settings.go
@@ -13,34 +13,44 @@ const (
 	vsCodeExtensionsDirEnv = "VSCODE_EXTENSIONS_DIR"
 )
 
-func configDir() (string, error) {
+func configDir(insiders bool) (string, error) {
 	if env, ok := os.LookupEnv(vsCodeConfigDirEnv); ok {
 		return os.ExpandEnv(env), nil
 	}
 
-	var path string
+	var basePath string
 	switch runtime.GOOS {
 	case "linux":
-		path = os.ExpandEnv("$HOME/.config/Code/User/")
+		basePath = os.ExpandEnv("$HOME/.config")
 	case "darwin":
-		path = os.ExpandEnv("$HOME/Library/Application Support/Code/User/")
+		basePath = os.ExpandEnv("$HOME/Library/Application Support")
 	default:
 		return "", xerrors.Errorf("unsupported platform: %s", runtime.GOOS)
 	}
-	return filepath.Clean(path), nil
+
+	if insiders {
+		return filepath.Join(basePath, "Code - Insiders", "User"), nil
+	}
+
+	return filepath.Join(basePath, "Code", "User"), nil
 }
 
-func extensionsDir() (string, error) {
+func extensionsDir(insiders bool) (string, error) {
 	if env, ok := os.LookupEnv(vsCodeExtensionsDirEnv); ok {
 		return os.ExpandEnv(env), nil
 	}
 
-	var path string
+	var basePath string
 	switch runtime.GOOS {
 	case "linux", "darwin":
-		path = os.ExpandEnv("$HOME/.vscode/extensions/")
+		basePath = os.ExpandEnv("$HOME")
 	default:
 		return "", xerrors.Errorf("unsupported platform: %s", runtime.GOOS)
 	}
-	return filepath.Clean(path), nil
+
+	if insiders {
+		return filepath.Join(basePath, ".vscode-insiders", "extensions"), nil
+	}
+
+	return filepath.Join(basePath, ".vscode", "extensions"), nil
 }


### PR DESCRIPTION
This adds the option to use VSCode Insiders default configuration without setting the environment variables 